### PR TITLE
fix showtime Delete method and check Duration

### DIFF
--- a/src/main/java/com/att/tdp/popcorn_palace/controller/TicketController.java
+++ b/src/main/java/com/att/tdp/popcorn_palace/controller/TicketController.java
@@ -29,11 +29,4 @@ public class TicketController {
         return ResponseEntity.ok(bookedTicket);
     }
 
-    @DeleteMapping("/{ticketId}")
-    @Operation(summary = "Cancel a ticket")
-    public ResponseEntity<String> cancelTicket(@PathVariable Long ticketId) {
-        log.info("Received request to cancel ticket ID: {}", ticketId);
-        ticketService.cancelTicket(ticketId);
-        return ResponseEntity.ok("Ticket deleted successfully");
-    }
 }

--- a/src/main/java/com/att/tdp/popcorn_palace/dto/ShowtimeRequest.java
+++ b/src/main/java/com/att/tdp/popcorn_palace/dto/ShowtimeRequest.java
@@ -11,10 +11,10 @@ import java.time.LocalDateTime;
 @Builder
 public class ShowtimeRequest {
     @NotNull
-    private Double price;
+    private Long movieId;
 
     @NotNull
-    private Long movieId;
+    private Double price;
 
     @NotBlank
     private String theater;
@@ -24,8 +24,5 @@ public class ShowtimeRequest {
 
     @NotNull
     private LocalDateTime endTime;
-
-    //@NotNull(message = "Total seats are mandatory")
-    //private Integer totalSeats;
 }
 

--- a/src/main/java/com/att/tdp/popcorn_palace/model/Ticket.java
+++ b/src/main/java/com/att/tdp/popcorn_palace/model/Ticket.java
@@ -17,7 +17,7 @@ public class Ticket {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     @Schema(example = "84438967-f68f-4fa0-b620-0f08217e76af")
-    private UUID id;
+    private UUID bookingId;
 
     @ManyToOne
     @JoinColumn(name = "showtime_id")

--- a/src/main/java/com/att/tdp/popcorn_palace/repository/TicketRepository.java
+++ b/src/main/java/com/att/tdp/popcorn_palace/repository/TicketRepository.java
@@ -12,4 +12,6 @@ public interface TicketRepository extends JpaRepository<Ticket, Long> {
 
     @Query("SELECT COUNT(t) FROM Ticket t WHERE t.showtime.id = :showtimeId")
     int countBookedSeatsByShowtime(Long showtimeId);
+
+    void deleteByShowtimeId(Long showtimeId);
 }

--- a/src/main/java/com/att/tdp/popcorn_palace/service/TicketService.java
+++ b/src/main/java/com/att/tdp/popcorn_palace/service/TicketService.java
@@ -30,12 +30,8 @@ public class TicketService {
             throw new IllegalArgumentException("Seat already booked");
         }
 
-        if (showtime.getAvailableSeats() == 0) {
+        if (showtime.getAvailableSeats() <= 0) {
             throw new IllegalArgumentException("No seats available");
-        }
-
-        if (showtime.getAvailableSeats() < 0) {
-            throw new IllegalArgumentException("Seats Number Illegal");
         }
 
         //if (ticketRepository.countBookedSeatsByShowtime(showtime.getId()) <= 0) {
@@ -59,19 +55,8 @@ public class TicketService {
                 .userId(ticketRequest.getUserId())
                 .build();
         Ticket bookedTicket = ticketRepository.save(ticket);
-        log.info("Ticket booked with ID: {}", bookedTicket.getId());
+        log.info("Ticket booked with ID: {}", bookedTicket.getBookingId());
         return bookedTicket;
     }
 
-    public void cancelTicket(Long ticketId) {
-        Ticket ticket = ticketRepository.findById(ticketId)
-                .orElseThrow(() -> new IllegalArgumentException("Ticket with ID " + ticketId + " not found"));
-
-        Showtime showtime = ticket.getShowtime();
-        showtime.setAvailableSeats(showtime.getAvailableSeats() + 1);
-        showtimeRepository.save(showtime);
-
-        ticketRepository.delete(ticket);
-        log.info("Ticket with ID {} cancelled and seat released", ticketId);
-    }
 }


### PR DESCRIPTION
It is not possible to delete a showtime once tickets are booked for it. I've updated that deleting a showtime will remove all tickets associated with it.

As well, make sure the time difference between the start and end times is at least the movie's duration when you add or change showTimes